### PR TITLE
fix: persist only completed articles

### DIFF
--- a/src/app/universe/[universeSlug]/wiki/[articleSlug]/components/ArticleRenderer.tsx
+++ b/src/app/universe/[universeSlug]/wiki/[articleSlug]/components/ArticleRenderer.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { use, useEffect, useLayoutEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { readArticleStream } from '@/lib/readArticleStream';
 import { slugify } from '@/lib/slugify';
 import styles from './ArticleRenderer.module.css';
 
@@ -19,59 +20,38 @@ export default function ArticleRenderer({
 
 	const articleStream = use(articleTextStream);
 	const [receivedArticleText, setReceivedArticleText] = useState<string>('');
+	const [streamError, setStreamError] = useState<string | null>(null);
 
 	useEffect(() => {
 		setReceivedArticleText('');
+		setStreamError(null);
 		if (typeof articleStream === 'string') {
 			setReceivedArticleText(articleStream);
 			return;
 		}
 
-		(async () => {
-			console.log('Processing article stream...');
+		const abortController = new AbortController();
 
-			if (articleStream.locked) {
-				// Maybe just being released by an earlier effect render
-				console.log('Article stream is locked, waiting for it to unlock...');
-				await new Promise((resolve) => setTimeout(resolve, 100));
-
-				if (articleStream.locked) {
-					console.warn('Article stream is still locked, skipping processing.');
-					return;
-				}
-			}
-
-			let cancelled = false;
-			const reader = articleStream.getReader();
-
-			function processChunk({ done, value }: ReadableStreamReadResult<string>) {
-				if (cancelled) {
-					return;
-				}
-
-				if (value) {
-					setReceivedArticleText((prev) => prev + value);
-				}
-
-				if (done) {
-					// Refresh in the background to ensure we show the article generation that
-					// was committed to the database
-					console.info('Article stream is over, refreshing data to sync...');
+		void readArticleStream(articleStream, {
+			signal: abortController.signal,
+			onChunk: (chunk) => {
+				setReceivedArticleText((previous) => previous + chunk);
+			},
+		})
+			.then(() => {
+				if (!abortController.signal.aborted) {
+					// AI SDK awaits article persistence before closing the stream.
 					router.refresh();
-					return;
 				}
+			})
+			.catch((error: unknown) => {
+				if (!abortController.signal.aborted) {
+					console.error('Article stream failed', error);
+					setStreamError('This article could not be fully generated.');
+				}
+			});
 
-				reader.read().then(processChunk);
-			}
-
-			reader.read().then(processChunk);
-
-			return () => {
-				cancelled = true;
-				reader.releaseLock();
-				reader.cancel();
-			};
-		})();
+		return () => abortController.abort();
 	}, [articleStream, router]);
 
 	const [scope, animate] = useAnimate();
@@ -92,38 +72,55 @@ export default function ArticleRenderer({
 			initial={{ opacity: 0, y: 15 }}
 			animate={{ opacity: 1, y: 0 }}
 		>
-			<ReactMarkdown
-				components={{
-					a: ({ node, ...props }) => {
-						const href = props.href || '';
-						if (href.startsWith('http')) {
-							return <a {...props} />;
-						}
-						return (
-							<Link
-								href={href}
-								onClick={async (e) => {
-									e.preventDefault();
+			{streamError ? (
+				<div role="alert" className="flex flex-col items-start gap-3">
+					<p>{streamError}</p>
+					<button
+						type="button"
+						className="underline underline-offset-4"
+						onClick={() => router.refresh()}
+					>
+						Try again
+					</button>
+				</div>
+			) : receivedArticleText ? (
+				<ReactMarkdown
+					components={{
+						a: ({ node, ...props }) => {
+							const href = props.href || '';
+							if (href.startsWith('http')) {
+								return <a {...props} />;
+							}
+							return (
+								<Link
+									href={href}
+									onClick={async (e) => {
+										e.preventDefault();
 
-									await animate(
-										scope.current,
-										{
-											opacity: 0,
-										},
-										{
-											duration: 0.15,
-										},
-									);
-									router.push(href);
-								}}
-								{...props}
-							/>
-						);
-					},
-				}}
-			>
-				{makeArticleReferencesMarkdownLinks(receivedArticleText)}
-			</ReactMarkdown>
+										await animate(
+											scope.current,
+											{
+												opacity: 0,
+											},
+											{
+												duration: 0.15,
+											},
+										);
+										router.push(href);
+									}}
+									{...props}
+								/>
+							);
+						},
+					}}
+				>
+					{makeArticleReferencesMarkdownLinks(receivedArticleText)}
+				</ReactMarkdown>
+			) : (
+				<p role="status" className="text-muted-foreground">
+					Weaving article…
+				</p>
+			)}
 		</motion.article>
 	);
 }

--- a/src/app/universe/[universeSlug]/wiki/[articleSlug]/page.tsx
+++ b/src/app/universe/[universeSlug]/wiki/[articleSlug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { db } from '@/db';
 import { articles } from '@/db/schema/article';
 import { universes } from '@/db/schema/universe';
-import { indexArticle } from '@/lib/search';
+import { persistCompletedArticle } from '@/lib/persistArticle';
 import { unslugify } from '@/lib/slugify';
 import { weaveWikiArticle } from '@/lib/weave';
 import ArticleRenderer from './components/ArticleRenderer';
@@ -41,61 +41,36 @@ async function findOrCreateArticle({
 		notFound();
 	}
 
-	const weavedArticle = await weaveWikiArticle({ universe, title });
-
-	const [clientStream, backendStream] = weavedArticle.textStream.tee();
-
-	void (async () => {
-		const reader = backendStream.getReader();
-		let articleText = '';
-
-		async function wrapUpArticle() {
-			await db
-				.insert(articles)
-				.values({
+	const weavedArticle = await weaveWikiArticle({
+		universe,
+		title,
+		onFinish: async ({ text, finishReason }) => {
+			try {
+				await persistCompletedArticle({
 					universeId: universe.id,
-					slug: articleSlug,
+					articleSlug,
 					title,
-					text: articleText,
-				})
-				.onConflictDoNothing(); // If two generations happen simultaneously, keep the first one
-
-			// Get the generated article back, or the first one that was generated in case of conflicts
-			const [newArticle] = await db
-				.select()
-				.from(articles)
-				.where(eq(articles.slug, articleSlug))
-				.limit(1);
-
-			if (articleText === newArticle.text) {
-				// Our generation was the one inserted!
-				console.log(
-					`Weaved new article: ${universe.name} / ${newArticle.title}`,
+					text,
+					finishReason,
+				});
+				console.log(`Weaved new article: ${universe.name} / ${title}`);
+			} catch (error) {
+				console.error(
+					`Failed to persist article: ${universe.name} / ${title}`,
+					error,
 				);
-
-				await indexArticle(newArticle);
+				throw error;
 			}
+		},
+		onError: ({ error }) => {
+			console.error(
+				`Article generation failed: ${universe.name} / ${title}`,
+				error,
+			);
+		},
+	});
 
-			return newArticle.text;
-		}
-
-		function processChunk({ done, value }: ReadableStreamReadResult<string>) {
-			if (value) {
-				articleText += value;
-			}
-
-			if (done) {
-				void wrapUpArticle();
-				return;
-			}
-
-			reader.read().then(processChunk);
-		}
-
-		reader.read().then(processChunk);
-	})();
-
-	return clientStream;
+	return weavedArticle.textStream;
 }
 
 export default async function WikiArticlePage({

--- a/src/lib/persistArticle.spec.ts
+++ b/src/lib/persistArticle.spec.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { returning, onConflictDoNothing, values, insert, indexArticle } =
+	vi.hoisted(() => {
+		const returning = vi.fn();
+		const onConflictDoNothing = vi.fn(() => ({ returning }));
+		const values = vi.fn(() => ({ onConflictDoNothing }));
+		const insert = vi.fn(() => ({ values }));
+		const indexArticle = vi.fn();
+
+		return { returning, onConflictDoNothing, values, insert, indexArticle };
+	});
+
+vi.mock('@/db', () => ({
+	db: { insert },
+}));
+
+vi.mock('./search', () => ({
+	indexArticle,
+}));
+
+import { persistCompletedArticle } from './persistArticle';
+
+const completedArticle = {
+	id: 'article-id',
+	createdAt: new Date('2026-06-30T09:00:00Z'),
+	universeId: 'universe-id',
+	slug: 'silver-road-gardens',
+	title: 'Silver Road Gardens',
+	text: '# Silver Road Gardens\n\nA complete article.',
+};
+
+describe('persistCompletedArticle', () => {
+	beforeEach(() => {
+		returning.mockReset();
+		onConflictDoNothing.mockClear();
+		values.mockClear();
+		insert.mockClear();
+		indexArticle.mockReset();
+	});
+
+	test('persists and indexes a naturally completed article', async () => {
+		returning.mockResolvedValue([completedArticle]);
+
+		await persistCompletedArticle({
+			universeId: completedArticle.universeId,
+			articleSlug: completedArticle.slug,
+			title: completedArticle.title,
+			text: completedArticle.text,
+			finishReason: 'stop',
+		});
+
+		expect(values).toHaveBeenCalledWith({
+			universeId: completedArticle.universeId,
+			slug: completedArticle.slug,
+			title: completedArticle.title,
+			text: completedArticle.text,
+		});
+		expect(indexArticle).toHaveBeenCalledWith(completedArticle);
+	});
+
+	test.each([
+		'length',
+		'content-filter',
+		'error',
+	] as const)('does not persist a generation finished with %s', async (finishReason) => {
+		await expect(
+			persistCompletedArticle({
+				universeId: completedArticle.universeId,
+				articleSlug: completedArticle.slug,
+				title: completedArticle.title,
+				text: completedArticle.text,
+				finishReason,
+			}),
+		).rejects.toThrow(`Incomplete article generation: ${finishReason}`);
+
+		expect(insert).not.toHaveBeenCalled();
+		expect(indexArticle).not.toHaveBeenCalled();
+	});
+
+	test('does not persist an empty completion', async () => {
+		await expect(
+			persistCompletedArticle({
+				universeId: completedArticle.universeId,
+				articleSlug: completedArticle.slug,
+				title: completedArticle.title,
+				text: '   ',
+				finishReason: 'stop',
+			}),
+		).rejects.toThrow('Article generation returned no text');
+
+		expect(insert).not.toHaveBeenCalled();
+		expect(indexArticle).not.toHaveBeenCalled();
+	});
+
+	test('does not index when another generation wins the insert race', async () => {
+		returning.mockResolvedValue([]);
+
+		await persistCompletedArticle({
+			universeId: completedArticle.universeId,
+			articleSlug: completedArticle.slug,
+			title: completedArticle.title,
+			text: completedArticle.text,
+			finishReason: 'stop',
+		});
+
+		expect(indexArticle).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/persistArticle.ts
+++ b/src/lib/persistArticle.ts
@@ -1,0 +1,43 @@
+import type { FinishReason } from 'ai';
+import { db } from '@/db';
+import { articles } from '@/db/schema/article';
+import { indexArticle } from './search';
+
+interface PersistCompletedArticleOptions {
+	universeId: string;
+	articleSlug: string;
+	title: string;
+	text: string;
+	finishReason: FinishReason;
+}
+
+export async function persistCompletedArticle({
+	universeId,
+	articleSlug,
+	title,
+	text,
+	finishReason,
+}: PersistCompletedArticleOptions): Promise<void> {
+	if (finishReason !== 'stop') {
+		throw new Error(`Incomplete article generation: ${finishReason}`);
+	}
+
+	if (!text.trim()) {
+		throw new Error('Article generation returned no text');
+	}
+
+	const [article] = await db
+		.insert(articles)
+		.values({
+			universeId,
+			slug: articleSlug,
+			title,
+			text,
+		})
+		.onConflictDoNothing()
+		.returning();
+
+	if (article) {
+		await indexArticle(article);
+	}
+}

--- a/src/lib/readArticleStream.spec.ts
+++ b/src/lib/readArticleStream.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from 'vitest';
+import { readArticleStream } from './readArticleStream';
+
+describe('readArticleStream', () => {
+	test('delivers every chunk and resolves after a complete stream', async () => {
+		const onChunk = vi.fn();
+		const stream = new ReadableStream<string>({
+			start(controller) {
+				controller.enqueue('# Silver Road');
+				controller.enqueue(' Gardens');
+				controller.close();
+			},
+		});
+
+		await readArticleStream(stream, { onChunk });
+
+		expect(onChunk.mock.calls).toEqual([['# Silver Road'], [' Gardens']]);
+	});
+
+	test('rejects when the source stream fails', async () => {
+		const stream = new ReadableStream<string>({
+			start(controller) {
+				controller.error(new Error('provider disconnected'));
+			},
+		});
+
+		await expect(
+			readArticleStream(stream, { onChunk: vi.fn() }),
+		).rejects.toThrow('provider disconnected');
+	});
+
+	test('cancels without reporting an error when navigation aborts', async () => {
+		const cancel = vi.fn();
+		const abortController = new AbortController();
+		const stream = new ReadableStream<string>({ cancel });
+
+		const reading = readArticleStream(stream, {
+			onChunk: vi.fn(),
+			signal: abortController.signal,
+		});
+		abortController.abort();
+
+		await expect(reading).resolves.toBeUndefined();
+		expect(cancel).toHaveBeenCalledOnce();
+	});
+});

--- a/src/lib/readArticleStream.ts
+++ b/src/lib/readArticleStream.ts
@@ -1,0 +1,41 @@
+interface ReadArticleStreamOptions {
+	onChunk: (chunk: string) => void;
+	signal?: AbortSignal;
+}
+
+export async function readArticleStream(
+	stream: ReadableStream<string>,
+	{ onChunk, signal }: ReadArticleStreamOptions,
+): Promise<void> {
+	const reader = stream.getReader();
+	let aborted = signal?.aborted ?? false;
+
+	const abort = () => {
+		aborted = true;
+		void reader.cancel().catch(() => undefined);
+	};
+
+	signal?.addEventListener('abort', abort, { once: true });
+	if (aborted) {
+		abort();
+	}
+
+	try {
+		while (!aborted) {
+			const { done, value } = await reader.read();
+			if (done || aborted) {
+				return;
+			}
+			if (value) {
+				onChunk(value);
+			}
+		}
+	} catch (error) {
+		if (!aborted) {
+			throw error;
+		}
+	} finally {
+		signal?.removeEventListener('abort', abort);
+		reader.releaseLock();
+	}
+}

--- a/src/lib/weave.spec.ts
+++ b/src/lib/weave.spec.ts
@@ -33,6 +33,8 @@ describe('weave model selection', () => {
 			});
 		streamText.mockReturnValue({ textStream: new ReadableStream<string>() });
 		searchArticles.mockResolvedValue([]);
+		const onFinish = vi.fn();
+		const onError = vi.fn();
 
 		const universe = {
 			id: 'universe-id',
@@ -44,7 +46,12 @@ describe('weave model selection', () => {
 
 		await weaveUniverseName({ prompt: universe.prompt });
 		await weaveFirstArticleTitle({ universe });
-		await weaveWikiArticle({ universe, title: 'Silver Road Gardens' });
+		await weaveWikiArticle({
+			universe,
+			title: 'Silver Road Gardens',
+			onFinish,
+			onError,
+		});
 
 		expect(generateObject).toHaveBeenNthCalledWith(
 			1,
@@ -55,7 +62,11 @@ describe('weave model selection', () => {
 			expect.objectContaining({ model: 'openai/gpt-5-nano' }),
 		);
 		expect(streamText).toHaveBeenCalledWith(
-			expect.objectContaining({ model: 'openai/gpt-5-mini' }),
+			expect.objectContaining({
+				model: 'openai/gpt-5-mini',
+				onFinish,
+				onError,
+			}),
 		);
 	});
 });

--- a/src/lib/weave.ts
+++ b/src/lib/weave.ts
@@ -4,6 +4,11 @@ import { DEFAULT_MODEL, FAST_MODEL } from '@/ai';
 import type { Universe } from '@/db/schema/universe';
 import { searchArticles } from './search';
 
+type ArticleStreamCallbacks = Pick<
+	Parameters<typeof streamText>[0],
+	'onFinish' | 'onError'
+>;
+
 export async function weaveUniverseName({
 	prompt,
 }: {
@@ -68,10 +73,12 @@ export async function weaveFirstArticleTitle({
 export async function weaveWikiArticle({
 	universe,
 	title,
+	onFinish,
+	onError,
 }: {
 	universe: Universe;
 	title: string;
-}): Promise<{
+} & ArticleStreamCallbacks): Promise<{
 	textStream: ReturnType<typeof streamText>['textStream'];
 }> {
 	const references = await searchArticles(universe.id, title).then((results) =>
@@ -118,6 +125,8 @@ Begin the article now:`;
 	const { textStream } = streamText({
 		model: DEFAULT_MODEL,
 		prompt,
+		onFinish,
+		onError,
 	});
 
 	return {


### PR DESCRIPTION
## Summary
- Persist articles only after a natural, complete model finish.
- Show weaving and retry states while cleaning up stream readers correctly.

## Checks
- `npm test -- --run`
- `npm run typecheck`
- `npm run build`
- Local fresh-article generation and reload