### PR TITLE
[codex] remove pg_search leftovers

### DIFF
--- a/src/db/schema/paragraph.ts
+++ b/src/db/schema/paragraph.ts
@@ -21,11 +21,6 @@ export const paragraphs = pgTable(
 		),
 	},
 	(table) => [
-		// Keep the ParadeDB index during the additive migration. A later cleanup can
-		// remove it after lakebase_text has soaked in production.
-		index('paragraph_search_idx')
-			.using('bm25', table.id, table.text)
-			.with({ key_field: table.id.name }),
 		index('paragraph_search_lakebase_idx').using(
 			'lakebase_bm25',
 			table.searchTsv,

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -81,9 +81,7 @@ async function searchArticlesWithLakebaseText(
 		return matches;
 	}
 
-	// pg_search supported typo distance directly. lakebase_text intentionally
-	// sticks to Postgres FTS, so pg_trgm provides a fuzzy fallback when the BM25
-	// query has no exact/stemmed matches.
+	// pg_trgm provides a fuzzy fallback when BM25 has no exact or stemmed matches.
 	const fuzzyScore = sql<number>`word_similarity(${query}, ${paragraphs.text})`;
 	return db
 		.select(paragraphSelection(fuzzyScore))


### PR DESCRIPTION
## Summary

- remove the legacy ParadeDB `paragraph_search_idx` declaration from the Drizzle schema
- remove the obsolete `pg_search` migration comment from the search implementation
- leave the active `lakebase_text` BM25 and `pg_trgm` indexes unchanged

## Why

The Lakebase Search production deployment is healthy and both exact and typo-tolerant searches work on `wikiweaver.gaby.dev`. Keeping the old index in the application schema would cause future Drizzle schema generation to continue preserving a backend the application no longer uses.

## Validation

- production deployment `87743aa3ba344b3349bc1173e37ef5d19347e816`: READY
- production Vercel runtime errors: none
- production warning/error/fatal logs since deploy: none
- live exact search (`storage`): populated ranked results
- live typo search (`storge`): populated fuzzy results
- browser console: no warnings or errors
- Biome: passed with 3 pre-existing CSS warnings
- TypeScript: passed
- Vitest: 20 tests passed

## Database cleanup

This PR changes code/schema declarations only. After it is merged and the Lakebase deployment has had enough soak time, production cleanup remains a separate manual operation:

```sql
DROP INDEX IF EXISTS "paragraph_search_idx";
DROP EXTENSION IF EXISTS pg_search;
VACUUM ANALYZE "paragraphs";
```
