### PR TITLE
chore: refresh security dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,8 @@
 				"drizzle-orm": "^0.45.2",
 				"lucide-react": "^0.556.0",
 				"motion": "^12.18.1",
-				"next": "^16.2.7",
-				"postcss": "^8.5.10",
+				"next": "^16.2.11",
+				"postcss": "^8.5.23",
 				"react": "^19.2.1",
 				"react-dom": "^19.2.1",
 				"react-hook-form": "^7.58.1",
@@ -42,10 +42,10 @@
 				"@types/node": "^24",
 				"@types/react": "^19.2.7",
 				"@types/react-dom": "^19.2.3",
-				"drizzle-kit": "^0.31.1",
+				"drizzle-kit": "^0.31.10",
 				"tw-animate-css": "^1.3.4",
 				"typescript": "^5.9.3",
-				"vercel": "^54.13.0",
+				"vercel": "^54.21.1",
 				"vitest": "^4.1.0"
 			}
 		},
@@ -805,9 +805,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-			"integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -822,9 +822,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-			"integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
 			"cpu": [
 				"arm"
 			],
@@ -839,9 +839,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-			"integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
 			"cpu": [
 				"arm64"
 			],
@@ -856,9 +856,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-			"integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
 			"cpu": [
 				"x64"
 			],
@@ -873,9 +873,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-			"integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+			"integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
 			"cpu": [
 				"arm64"
 			],
@@ -890,9 +890,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-			"integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
 			"cpu": [
 				"x64"
 			],
@@ -907,9 +907,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-			"integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
 			"cpu": [
 				"arm64"
 			],
@@ -924,9 +924,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-			"integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
 			"cpu": [
 				"x64"
 			],
@@ -941,9 +941,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-			"integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
 			"cpu": [
 				"arm"
 			],
@@ -958,9 +958,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-			"integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -975,9 +975,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-			"integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
 			"cpu": [
 				"ia32"
 			],
@@ -992,9 +992,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-			"integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
 			"cpu": [
 				"loong64"
 			],
@@ -1009,9 +1009,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-			"integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1026,9 +1026,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-			"integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1043,9 +1043,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-			"integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1060,9 +1060,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-			"integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
 			"cpu": [
 				"s390x"
 			],
@@ -1077,9 +1077,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-			"integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
 			"cpu": [
 				"x64"
 			],
@@ -1094,9 +1094,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-			"integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1111,9 +1111,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-			"integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1128,9 +1128,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-			"integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1145,9 +1145,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-			"integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
 			"cpu": [
 				"x64"
 			],
@@ -1179,9 +1179,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-			"integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
 			"cpu": [
 				"x64"
 			],
@@ -1196,9 +1196,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-			"integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1213,9 +1213,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-			"integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1230,9 +1230,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-			"integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+			"integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
 			"cpu": [
 				"x64"
 			],
@@ -2170,15 +2170,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@next/env": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.7.tgz",
-			"integrity": "sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.11.tgz",
+			"integrity": "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==",
 			"license": "MIT"
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.7.tgz",
-			"integrity": "sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.11.tgz",
+			"integrity": "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2192,9 +2192,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.7.tgz",
-			"integrity": "sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.11.tgz",
+			"integrity": "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==",
 			"cpu": [
 				"x64"
 			],
@@ -2208,11 +2208,14 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.7.tgz",
-			"integrity": "sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.11.tgz",
+			"integrity": "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2224,11 +2227,14 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.7.tgz",
-			"integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.11.tgz",
+			"integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2240,11 +2246,14 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.7.tgz",
-			"integrity": "sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.11.tgz",
+			"integrity": "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2256,11 +2265,14 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.7.tgz",
-			"integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.11.tgz",
+			"integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2272,9 +2284,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.7.tgz",
-			"integrity": "sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.11.tgz",
+			"integrity": "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==",
 			"cpu": [
 				"arm64"
 			],
@@ -2288,9 +2300,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.7.tgz",
-			"integrity": "sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.11.tgz",
+			"integrity": "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==",
 			"cpu": [
 				"x64"
 			],
@@ -2487,6 +2499,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2504,6 +2519,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2521,6 +2539,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2538,6 +2559,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2555,6 +2579,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2572,6 +2599,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2589,6 +2619,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2606,6 +2639,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3249,6 +3285,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3266,6 +3305,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3317,6 +3359,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3334,6 +3379,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3954,14 +4002,15 @@
 			}
 		},
 		"node_modules/@vercel/backends": {
-			"version": "0.8.14",
-			"resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.8.14.tgz",
-			"integrity": "sha512-jgepdZh7E4ameCUSt/b28ImFd9Bz1VX71lKwD/ThtZ7nGIwi5SJ9hwyURvH60c4rNW6nKxMD/iSOlcgQOfrK3A==",
+			"version": "0.8.21",
+			"resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.8.21.tgz",
+			"integrity": "sha512-c0mKXgfxMyb44+kMGbNoQJomf37QAfd6yL/2imhAnAChR1Ddkxk6uwbrOC89LcG+QmN2ZoEFUSJdMInSfreztw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/build-utils": "13.30.0",
+				"@vercel/build-utils": "13.32.2",
 				"@vercel/nft": "1.10.0",
+				"@vercel/static-config": "3.4.0",
 				"execa": "3.2.0",
 				"fs-extra": "11.1.0",
 				"get-port": "5.1.1",
@@ -3969,7 +4018,8 @@
 				"path-to-regexp": "8.3.0",
 				"resolve.exports": "2.0.3",
 				"rolldown": "1.0.0-rc.1",
-				"srvx": "0.8.9",
+				"srvx": "0.11.16",
+				"ts-morph": "12.0.0",
 				"tsx": "4.21.0",
 				"zod": "3.22.4"
 			}
@@ -4002,9 +4052,9 @@
 			}
 		},
 		"node_modules/@vercel/build-utils": {
-			"version": "13.30.0",
-			"resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.30.0.tgz",
-			"integrity": "sha512-fLIa8cpELsSoWbcxshaqegwlTCfKnbgsDmA6uIb+oA797xvSmYkPu5a781aRYCRdghgyOZF7NCSVgtZjHjunnQ==",
+			"version": "13.32.2",
+			"resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.32.2.tgz",
+			"integrity": "sha512-XgATgMjt2NHF6HHo1wii6f43qlWjaFx3o+9L7aOUPLQgqwgYp2BGwuuBjg8U6sNgut1QsmFBMvNqTAUBvack9Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -4014,13 +4064,13 @@
 			}
 		},
 		"node_modules/@vercel/cervel": {
-			"version": "0.1.22",
-			"resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.1.22.tgz",
-			"integrity": "sha512-YbL2AosH3FaBLJZu4GYdVMkFv+5cbWwwSrRBTGN52odynQUudTUQfbc7rCzPyNQLdk2QC4w2IDYRD+nqgojhVg==",
+			"version": "0.1.29",
+			"resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.1.29.tgz",
+			"integrity": "sha512-tjwW6bj1g9qwOO0y/3WTGiarvyWmsWOtLkPB0esFmnscMZCxRqzNh0WJqrbbWxMdC5A2LXzDDHuZ4sXpRg4Tqw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/backends": "0.8.14"
+				"@vercel/backends": "0.8.21"
 			},
 			"bin": {
 				"cervel": "bin/cervel.mjs"
@@ -4070,6 +4120,13 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
+		"node_modules/@vercel/container": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@vercel/container/-/container-0.0.4.tgz",
+			"integrity": "sha512-lbUnpg2Iawoi0oDlFE6Se43FNUd2B2nMnCXD9Af7NsysMENFaNu2ajzgsocTxt+O6djUgW9IdBnIRHgnHs+vZQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/@vercel/detect-agent": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@vercel/detect-agent/-/detect-agent-1.2.3.tgz",
@@ -4081,13 +4138,13 @@
 			}
 		},
 		"node_modules/@vercel/elysia": {
-			"version": "0.1.93",
-			"resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.93.tgz",
-			"integrity": "sha512-36yzZJVU9o7/CcH1TbqeGTRwBePDaCEzv1CYfS183HdLXzsD+pOjOkTqZOBJu7h9aHpJFCCau55Ed0xOQC2jhA==",
+			"version": "0.1.98",
+			"resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.98.tgz",
+			"integrity": "sha512-VJMPfvslPFP5lg7oNN+BZEXHdaejmI25OEyco5OvZWpR80MYpTPil+2+hbkoR6lN3kVUC9/xahtgsdfouOvNbA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/node": "5.8.17",
+				"@vercel/node": "5.8.22",
 				"@vercel/static-config": "3.4.0"
 			}
 		},
@@ -4099,15 +4156,15 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@vercel/express": {
-			"version": "0.1.105",
-			"resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.105.tgz",
-			"integrity": "sha512-F+QRQxWWKdeztW4MKPkzXl/Ajc8j1qOffCp1tt8+YPaNiqZtxpn7FjIYRXHbfR1aepfaEkDRDD7o2qxmmaUU5w==",
+			"version": "0.1.112",
+			"resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.112.tgz",
+			"integrity": "sha512-Xpw1/+G/NpWYzBh3HqT+npYKo+yrLhSKC+hekBYCoddfDjSTevF1hQSbdEo7oHbZbgQo7h5Rb2vWVQ404zSmkA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/cervel": "0.1.22",
+				"@vercel/cervel": "0.1.29",
 				"@vercel/nft": "1.10.0",
-				"@vercel/node": "5.8.17",
+				"@vercel/node": "5.8.22",
 				"@vercel/static-config": "3.4.0",
 				"fs-extra": "11.1.0",
 				"path-to-regexp": "8.3.0",
@@ -4126,13 +4183,13 @@
 			}
 		},
 		"node_modules/@vercel/fastify": {
-			"version": "0.1.96",
-			"resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.96.tgz",
-			"integrity": "sha512-4Uq6GVmi0ksQxIHp4FDUhgoz47uacxZm42XT04SK5gzX5v5UmZXWZPprZjkwwk/2gmP/rF2qKqJ0nu6OsI+yDw==",
+			"version": "0.1.101",
+			"resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.101.tgz",
+			"integrity": "sha512-+oUCBpSs8ANQmdQB6CTCWTfdxKutCzKEMkMtUJVLVnO0eaiONADkZeaFjjZwMl4Cg6z49ifhJ3QVJD1IWwIwsA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/node": "5.8.17",
+				"@vercel/node": "5.8.22",
 				"@vercel/static-config": "3.4.0"
 			}
 		},
@@ -4275,14 +4332,14 @@
 			}
 		},
 		"node_modules/@vercel/gatsby-plugin-vercel-builder": {
-			"version": "2.2.19",
-			"resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.2.19.tgz",
-			"integrity": "sha512-dA1ZWZHruRjFbLToqjcPHUyh5J7/Cl3qGFDge87ghAInuy/aXfalApzFbw61OIopGx0SSsIYi/8kbpJ+SbQ6ZQ==",
+			"version": "2.2.24",
+			"resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.2.24.tgz",
+			"integrity": "sha512-+rqPToquzHOnSsist6FylJY++Z7ScRvl87gJshGhYYXJSCMki5zquX+D8wliOb5H0SW3KGwmTNQ10gUJt52c8w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@sinclair/typebox": "0.25.24",
-				"@vercel/build-utils": "13.30.0",
+				"@vercel/build-utils": "13.32.2",
 				"esbuild": "0.27.0",
 				"etag": "1.8.1",
 				"fs-extra": "11.1.0"
@@ -4756,32 +4813,32 @@
 			}
 		},
 		"node_modules/@vercel/go": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.9.0.tgz",
-			"integrity": "sha512-vGbEwckvtr9UXKDz3qEHUE7VHJGG/9VQLuScgHytksfZyX8dzvNPgEuBKBbhPaMwua8pUCZKQqNxFM3Dul+bLA==",
+			"version": "3.10.2",
+			"resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.10.2.tgz",
+			"integrity": "sha512-ZJqx1GzD1qqMkI92jEHp04zCwbZ7tNwcgI58e7t8HiYvILwCZ4Rvq0hfjTjsk+0Zn8A369qs4eAHvCYu38uB5A==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@vercel/h3": {
-			"version": "0.1.102",
-			"resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.102.tgz",
-			"integrity": "sha512-UnHFLBemE2UfvQ+w2z2zxGcvyiShQ8eMdk3ag2sV71wbyatnXwmio8HOy//B2ZIEQNEid5gW2HjWOXLtrR+E2Q==",
+			"version": "0.1.107",
+			"resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.107.tgz",
+			"integrity": "sha512-Vqo5AvE5ku3MIWAi56KlYbLIg/PfX7Xxp94xbNa7J7dbREbO8PZWD0QLKvOw1uGqyoa5YqNZZ3RdtCfDq9Z6oA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/node": "5.8.17",
+				"@vercel/node": "5.8.22",
 				"@vercel/static-config": "3.4.0"
 			}
 		},
 		"node_modules/@vercel/hono": {
-			"version": "0.2.96",
-			"resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.96.tgz",
-			"integrity": "sha512-h4G0GSo5omhXS1iqimIcekcW7THEAnUGd6eioDNnSqwS3L0CGEvvTPUekJDyJcybsqnKslH1XTZA40f4b9MPHg==",
+			"version": "0.2.101",
+			"resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.101.tgz",
+			"integrity": "sha512-sm24D5OUJEo9cuvPHeVgouuc0zhZdIhX28BdtvIek5b7FGmvOE8VExOhteWU5YufhJR0M1y1zbbVC2ULr/arHw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vercel/nft": "1.10.0",
-				"@vercel/node": "5.8.17",
+				"@vercel/node": "5.8.22",
 				"@vercel/static-config": "3.4.0",
 				"fs-extra": "11.1.0",
 				"path-to-regexp": "8.3.0",
@@ -4811,31 +4868,31 @@
 			}
 		},
 		"node_modules/@vercel/koa": {
-			"version": "0.1.76",
-			"resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.76.tgz",
-			"integrity": "sha512-6MuBn5RM2nHKfHKeBqbs3aaFJlBFDhOZgpC1ubLQG2B/EvnAfljB7FPIKCl1SwANAHisX7vQACinMedCbFdi+Q==",
+			"version": "0.1.81",
+			"resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.81.tgz",
+			"integrity": "sha512-sAavmnlTM9LhYPWAgIvWuKgpeozk/tB4ZPLe/Fl7qE6EJiN3sCjtaSatXhla5w1Zxy0veBI5u0LCcjref4Oxag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/node": "5.8.17",
+				"@vercel/node": "5.8.22",
 				"@vercel/static-config": "3.4.0"
 			}
 		},
 		"node_modules/@vercel/nestjs": {
-			"version": "0.2.97",
-			"resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.97.tgz",
-			"integrity": "sha512-KM9uBmC+a10EPJgtm0B/vfGsTaUEzxKkihTyaQ4PhSUQHJOABTv6TBpGKtwIM5P1vMLKUg9R0A2SUvkKdaALvA==",
+			"version": "0.2.102",
+			"resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.102.tgz",
+			"integrity": "sha512-CMDoq4dFBI1rLmAuya7UPXfcg7h0y1xdNVCeFhzlZOfp7EF1+PFkn3dVF8tIX46yiUFCz94weiLHSAoh+mRD4g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/node": "5.8.17",
+				"@vercel/node": "5.8.22",
 				"@vercel/static-config": "3.4.0"
 			}
 		},
 		"node_modules/@vercel/next": {
-			"version": "4.19.0",
-			"resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.19.0.tgz",
-			"integrity": "sha512-9B7juRNydQ9MU7xT8OE254ymhVrNdcOKlXrZ4anem8YEa34KvXjLczQhZEPdvTz9JaCXpYiEEGmd/D3t2oJ+Uw==",
+			"version": "4.20.3",
+			"resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.20.3.tgz",
+			"integrity": "sha512-8EaLV6GaVY7DvKlxFeGGy3I39C3CoB11WbH3q7Dr73eX0WBMOu8UqOVYIclVH79EJNp7Wc0qfdbNmK8+LrSgGA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -4877,9 +4934,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@vercel/node": {
-			"version": "5.8.17",
-			"resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.8.17.tgz",
-			"integrity": "sha512-n2DVzblqS43LTs4BV1iLfx8tjjrTegcSsyDgRzn70h6tQePYWjl+h0bU3X1stpITZtaYJSZYwVevuX1BJNZHHg==",
+			"version": "5.8.22",
+			"resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.8.22.tgz",
+			"integrity": "sha512-WfciIhDVh9RwFmvrWp7FAdYCBPV94bZvIo4JbaHqZbvBJ2Bmnv/Pgj1fTjjLKfnKTbLJy+8HN1FXB8KYDnwGZQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -4887,7 +4944,7 @@
 				"@edge-runtime/primitives": "4.1.0",
 				"@edge-runtime/vm": "3.2.0",
 				"@types/node": "20.11.0",
-				"@vercel/build-utils": "13.30.0",
+				"@vercel/build-utils": "13.32.2",
 				"@vercel/error-utils": "2.2.0",
 				"@vercel/nft": "1.10.0",
 				"@vercel/static-config": "3.4.0",
@@ -5456,9 +5513,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@vercel/python": {
-			"version": "6.44.1",
-			"resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.44.1.tgz",
-			"integrity": "sha512-wRYX8SKOmFGHLtQZvnhl3R405PgZFZqdqNXnrOsy7nxm5B8tkkqDSV6P8NhxOnoRm+fnQP3j+CzWpwTMbNZZgQ==",
+			"version": "6.48.0",
+			"resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.48.0.tgz",
+			"integrity": "sha512-delMxwzNTbzYLM/VcIKYZGr501AEAYD8bPdOtMKJtzBv8pkr5hCeN6NKdHPFaIbmmCunUmouFuFxfRtpDWLl4Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -5552,20 +5609,21 @@
 			"license": "MIT"
 		},
 		"node_modules/@vercel/ruby": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.4.0.tgz",
-			"integrity": "sha512-YI7Amyf09hHZWOqDHgJO92XcKh6Pye8rrmJFhlP6euG3o6QjoZzJj7Z2WzjSrDRGMewzEK4uz2+CbNpNS7gLog==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.5.1.tgz",
+			"integrity": "sha512-e23M7pfORQyyxSUmeQ8PqEnyLJ4swhtNrnyctU5E02UCaUYFm5YAdNfdPYRP4It874H4Wyvm+LV8u7CPBrfcPA==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@vercel/rust": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-1.3.0.tgz",
-			"integrity": "sha512-z1X0z1NM+ISunm/scgRpuENNwcKlh7DjXn0QvKE0n10DcaYqxkBQVK8iRA9X05xSK9AzPlnB9DHdGKiXZO5buw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-1.4.0.tgz",
+			"integrity": "sha512-/zRJtaf3pvdxZ7+tShmIo8StdbkCSBDcY7Gy7LOwNTIxm6GU9vkS+BlCwJHkOu6qNkbcSRH6ZQIeo4vNmqzKdQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"execa": "5",
+				"get-port": "5.1.1",
 				"smol-toml": "1.5.2"
 			}
 		},
@@ -5624,9 +5682,9 @@
 			"license": "ISC"
 		},
 		"node_modules/@vercel/sandbox": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-2.1.1.tgz",
-			"integrity": "sha512-gKhW+YlvU15Qxya7jQKByB+sqA1dWat5zx/rvxT52E3Ryg9MAIXgqD5wd1d+CoJDbdHL26gIOcksTZY5sFpplA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-2.4.0.tgz",
+			"integrity": "sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -5640,7 +5698,7 @@
 				"tar-stream": "3.1.7",
 				"undici": "^7.27.1",
 				"xdg-app-paths": "5.1.0",
-				"zod": "3.24.4"
+				"zod": "^4.1.1"
 			}
 		},
 		"node_modules/@vercel/sandbox/node_modules/@vercel/oidc": {
@@ -5664,9 +5722,9 @@
 			}
 		},
 		"node_modules/@vercel/sandbox/node_modules/undici": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-			"integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5684,16 +5742,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/@vercel/sandbox/node_modules/zod": {
-			"version": "3.24.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-			"integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@vercel/speed-insights": {
@@ -5731,14 +5779,14 @@
 			}
 		},
 		"node_modules/@vercel/static-build": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.10.3.tgz",
-			"integrity": "sha512-+IipWidX6mL1Zck8Khw4wSXHPSgDfkapvcuWA9wSCmhnk2GL2Iuu+6vab+g8UPahv+QDUYm8Tphhadg6dICZnA==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.11.4.tgz",
+			"integrity": "sha512-Cyjsg4yfiSSwRSq4TaYnxDzh3Cembx6hlUCKD0z3QCvEYFjTR3j1bFKk8haekwSB16qg25k9fiPEZMP7B/Azag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vercel/gatsby-plugin-vercel-analytics": "1.0.11",
-				"@vercel/gatsby-plugin-vercel-builder": "2.2.19",
+				"@vercel/gatsby-plugin-vercel-builder": "2.2.24",
 				"@vercel/static-config": "3.4.0",
 				"ts-morph": "12.0.0"
 			}
@@ -6026,13 +6074,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/b4a": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
@@ -6110,9 +6151,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6158,20 +6199,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/call-bind-apply-helpers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/caniuse-lite": {
@@ -6347,19 +6374,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/comma-separated-tokens": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -6411,13 +6425,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/cookie-es": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.1.tgz",
-			"integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -6507,16 +6514,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -6577,16 +6574,16 @@
 			}
 		},
 		"node_modules/drizzle-kit": {
-			"version": "0.31.8",
-			"resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.8.tgz",
-			"integrity": "sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==",
+			"version": "0.31.10",
+			"resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
+			"integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@drizzle-team/brocli": "^0.10.2",
 				"@esbuild-kit/esm-loader": "^2.5.5",
 				"esbuild": "^0.25.4",
-				"esbuild-register": "^3.5.0"
+				"tsx": "^4.21.0"
 			},
 			"bin": {
 				"drizzle-kit": "bin.cjs"
@@ -6717,21 +6714,6 @@
 				}
 			}
 		},
-		"node_modules/dunder-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/edge-runtime": {
 			"version": "2.5.9",
 			"resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.9.tgz",
@@ -6796,61 +6778,12 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/es-define-property": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/es-module-lexer": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
 			"integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/es-object-atoms": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-set-tostringtag": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
 		},
 		"node_modules/esast-util-from-estree": {
 			"version": "2.0.0",
@@ -6885,9 +6818,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-			"integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+			"integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -6898,44 +6831,49 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.5",
-				"@esbuild/android-arm": "0.25.5",
-				"@esbuild/android-arm64": "0.25.5",
-				"@esbuild/android-x64": "0.25.5",
-				"@esbuild/darwin-arm64": "0.25.5",
-				"@esbuild/darwin-x64": "0.25.5",
-				"@esbuild/freebsd-arm64": "0.25.5",
-				"@esbuild/freebsd-x64": "0.25.5",
-				"@esbuild/linux-arm": "0.25.5",
-				"@esbuild/linux-arm64": "0.25.5",
-				"@esbuild/linux-ia32": "0.25.5",
-				"@esbuild/linux-loong64": "0.25.5",
-				"@esbuild/linux-mips64el": "0.25.5",
-				"@esbuild/linux-ppc64": "0.25.5",
-				"@esbuild/linux-riscv64": "0.25.5",
-				"@esbuild/linux-s390x": "0.25.5",
-				"@esbuild/linux-x64": "0.25.5",
-				"@esbuild/netbsd-arm64": "0.25.5",
-				"@esbuild/netbsd-x64": "0.25.5",
-				"@esbuild/openbsd-arm64": "0.25.5",
-				"@esbuild/openbsd-x64": "0.25.5",
-				"@esbuild/sunos-x64": "0.25.5",
-				"@esbuild/win32-arm64": "0.25.5",
-				"@esbuild/win32-ia32": "0.25.5",
-				"@esbuild/win32-x64": "0.25.5"
+				"@esbuild/aix-ppc64": "0.25.12",
+				"@esbuild/android-arm": "0.25.12",
+				"@esbuild/android-arm64": "0.25.12",
+				"@esbuild/android-x64": "0.25.12",
+				"@esbuild/darwin-arm64": "0.25.12",
+				"@esbuild/darwin-x64": "0.25.12",
+				"@esbuild/freebsd-arm64": "0.25.12",
+				"@esbuild/freebsd-x64": "0.25.12",
+				"@esbuild/linux-arm": "0.25.12",
+				"@esbuild/linux-arm64": "0.25.12",
+				"@esbuild/linux-ia32": "0.25.12",
+				"@esbuild/linux-loong64": "0.25.12",
+				"@esbuild/linux-mips64el": "0.25.12",
+				"@esbuild/linux-ppc64": "0.25.12",
+				"@esbuild/linux-riscv64": "0.25.12",
+				"@esbuild/linux-s390x": "0.25.12",
+				"@esbuild/linux-x64": "0.25.12",
+				"@esbuild/netbsd-arm64": "0.25.12",
+				"@esbuild/netbsd-x64": "0.25.12",
+				"@esbuild/openbsd-arm64": "0.25.12",
+				"@esbuild/openbsd-x64": "0.25.12",
+				"@esbuild/openharmony-arm64": "0.25.12",
+				"@esbuild/sunos-x64": "0.25.12",
+				"@esbuild/win32-arm64": "0.25.12",
+				"@esbuild/win32-ia32": "0.25.12",
+				"@esbuild/win32-x64": "0.25.12"
 			}
 		},
-		"node_modules/esbuild-register": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
-			"integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
+		"node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+			"cpu": [
+				"arm64"
+			],
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"peerDependencies": {
-				"esbuild": ">=0.12 <1"
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/escodegen": {
@@ -7264,23 +7202,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/form-data": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.4",
-				"mime-types": "^2.1.35"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/framer-motion": {
 			"version": "12.23.25",
 			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.25.tgz",
@@ -7338,16 +7259,6 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/generic-pool": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.2.tgz",
@@ -7356,31 +7267,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
-			}
-		},
-		"node_modules/get-intrinsic": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"math-intrinsics": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/get-nonce": {
@@ -7403,20 +7289,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/get-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"dunder-proto": "^1.0.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/get-stream": {
@@ -7505,16 +7377,16 @@
 			}
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
@@ -7533,66 +7405,11 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/gopd": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"license": "ISC"
-		},
-		"node_modules/has-symbols": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-symbols": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/hasown": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
 		},
 		"node_modules/hast-util-to-estree": {
 			"version": "3.1.3",
@@ -7973,10 +7790,20 @@
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -8342,16 +8169,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/math-intrinsics": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
@@ -9325,9 +9142,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -9353,12 +9170,12 @@
 			}
 		},
 		"node_modules/next": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/next/-/next-16.2.7.tgz",
-			"integrity": "sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/next/-/next-16.2.11.tgz",
+			"integrity": "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "16.2.7",
+				"@next/env": "16.2.11",
 				"@swc/helpers": "0.5.15",
 				"baseline-browser-mapping": "^2.9.19",
 				"caniuse-lite": "^1.0.30001579",
@@ -9372,14 +9189,14 @@
 				"node": ">=20.9.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "16.2.7",
-				"@next/swc-darwin-x64": "16.2.7",
-				"@next/swc-linux-arm64-gnu": "16.2.7",
-				"@next/swc-linux-arm64-musl": "16.2.7",
-				"@next/swc-linux-x64-gnu": "16.2.7",
-				"@next/swc-linux-x64-musl": "16.2.7",
-				"@next/swc-win32-arm64-msvc": "16.2.7",
-				"@next/swc-win32-x64-msvc": "16.2.7",
+				"@next/swc-darwin-arm64": "16.2.11",
+				"@next/swc-darwin-x64": "16.2.11",
+				"@next/swc-linux-arm64-gnu": "16.2.11",
+				"@next/swc-linux-arm64-musl": "16.2.11",
+				"@next/swc-linux-x64-gnu": "16.2.11",
+				"@next/swc-linux-x64-musl": "16.2.11",
+				"@next/swc-win32-arm64-msvc": "16.2.11",
+				"@next/swc-win32-x64-msvc": "16.2.11",
 				"sharp": "^0.34.5"
 			},
 			"peerDependencies": {
@@ -9815,9 +9632,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -9834,7 +9651,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -10446,15 +10263,16 @@
 			"license": "MIT"
 		},
 		"node_modules/sandbox": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/sandbox/-/sandbox-3.1.2.tgz",
-			"integrity": "sha512-g93rma0Z9Aa6EoTktzYnGZmQvMzm7j73BekJIMwmkdWR5uryZ+6hBCADtd3JKGAB27k+ubnG7HHsZqtscAMzIQ==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/sandbox/-/sandbox-3.4.0.tgz",
+			"integrity": "sha512-JPdADikobt6zFuuCRhl6whNrCJlLPxpUmT/hNxLij70mkpeejHKDN+HeVlrdHI8snDTzRIiF3Ye8KyMIyVWA+A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/sandbox": "2.1.1",
+				"@vercel/sandbox": "2.4.0",
 				"async-retry": "1.3.3",
 				"debug": "^4.4.1",
+				"ws": "^8.21.0",
 				"zod": "^4.1.1"
 			},
 			"bin": {
@@ -10671,14 +10489,11 @@
 			}
 		},
 		"node_modules/srvx": {
-			"version": "0.8.9",
-			"resolved": "https://registry.npmjs.org/srvx/-/srvx-0.8.9.tgz",
-			"integrity": "sha512-wYc3VLZHRzwYrWJhkEqkhLb31TI0SOkfYZDkUhXdp3NoCnNS0FqajiQszZZjfow/VYEuc6Q5sZh9nM6kPy2NBQ==",
+			"version": "0.11.16",
+			"resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.16.tgz",
+			"integrity": "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"cookie-es": "^2.0.0"
-			},
 			"bin": {
 				"srvx": "bin/srvx.mjs"
 			},
@@ -10866,10 +10681,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.7",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-			"integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
-			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"version": "7.5.22",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+			"integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -11803,45 +11617,46 @@
 			}
 		},
 		"node_modules/vercel": {
-			"version": "54.13.0",
-			"resolved": "https://registry.npmjs.org/vercel/-/vercel-54.13.0.tgz",
-			"integrity": "sha512-EgJosSfOkJkzWacaV0EIpvcQUSrTtaknIWvLylcx/nBoNtEw05nOEuXH325aNg6EvrtqgHBB58R1UWZDyG+UkQ==",
+			"version": "54.21.1",
+			"resolved": "https://registry.npmjs.org/vercel/-/vercel-54.21.1.tgz",
+			"integrity": "sha512-GDs3FqEwZJHOyrzUXMjQBg8Fd1qOKOBuzE1exrhKq6hHBaHHuGnfvfHzRpm7j9CC+SjnRr/CY30tUNyU28gN4A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@vercel/backends": "0.8.14",
+				"@vercel/backends": "0.8.21",
 				"@vercel/blob": "2.4.0",
-				"@vercel/build-utils": "13.30.0",
+				"@vercel/build-utils": "13.32.2",
 				"@vercel/cli-auth": "0.3.0",
 				"@vercel/cli-config": "0.2.0",
+				"@vercel/container": "0.0.4",
 				"@vercel/detect-agent": "1.2.3",
-				"@vercel/elysia": "0.1.93",
-				"@vercel/express": "0.1.105",
-				"@vercel/fastify": "0.1.96",
+				"@vercel/elysia": "0.1.98",
+				"@vercel/express": "0.1.112",
+				"@vercel/fastify": "0.1.101",
 				"@vercel/fun": "1.3.0",
-				"@vercel/go": "3.9.0",
-				"@vercel/h3": "0.1.102",
-				"@vercel/hono": "0.2.96",
+				"@vercel/go": "3.10.2",
+				"@vercel/h3": "0.1.107",
+				"@vercel/hono": "0.2.101",
 				"@vercel/hydrogen": "1.4.0",
-				"@vercel/koa": "0.1.76",
-				"@vercel/nestjs": "0.2.97",
-				"@vercel/next": "4.19.0",
-				"@vercel/node": "5.8.17",
+				"@vercel/koa": "0.1.81",
+				"@vercel/nestjs": "0.2.102",
+				"@vercel/next": "4.20.3",
+				"@vercel/node": "5.8.22",
 				"@vercel/prepare-flags-definitions": "0.3.0",
-				"@vercel/python": "6.44.1",
+				"@vercel/python": "6.48.0",
 				"@vercel/redwood": "2.5.0",
 				"@vercel/remix-builder": "5.9.1",
-				"@vercel/ruby": "2.4.0",
-				"@vercel/rust": "1.3.0",
-				"@vercel/static-build": "2.10.3",
+				"@vercel/ruby": "2.5.1",
+				"@vercel/rust": "1.4.0",
+				"@vercel/static-build": "2.11.4",
 				"chokidar": "4.0.0",
 				"esbuild": "0.27.0",
-				"form-data": "^4.0.0",
 				"jose": "5.9.6",
 				"luxon": "^3.4.0",
 				"proxy-agent": "6.4.0",
-				"sandbox": "3.1.2",
+				"sandbox": "3.4.0",
 				"smol-toml": "1.5.2",
+				"undici": "5.29.0",
 				"zod": "4.1.11"
 			},
 			"bin": {
@@ -12317,6 +12132,19 @@
 				"@esbuild/win32-arm64": "0.27.0",
 				"@esbuild/win32-ia32": "0.27.0",
 				"@esbuild/win32-x64": "0.27.0"
+			}
+		},
+		"node_modules/vercel/node_modules/undici": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/busboy": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/vercel/node_modules/zod": {
@@ -13160,6 +12988,28 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/ws": {
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/xdg-app-paths": {
 			"version": "5.5.1",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,12 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"overrides": {
+		"brace-expansion@^1.0.0": "1.1.16",
+		"brace-expansion@^5.0.0": "5.0.8",
+		"js-yaml@^4.0.0": "4.3.0",
 		"react": "$react",
-		"react-dom": "$react-dom"
+		"react-dom": "$react-dom",
+		"tar": "7.5.22"
 	},
 	"dependencies": {
 		"@heroicons/react": "^2.2.0",
@@ -34,8 +38,8 @@
 		"drizzle-orm": "^0.45.2",
 		"lucide-react": "^0.556.0",
 		"motion": "^12.18.1",
-		"next": "^16.2.7",
-		"postcss": "^8.5.10",
+		"next": "^16.2.11",
+		"postcss": "^8.5.23",
 		"react": "^19.2.1",
 		"react-dom": "^19.2.1",
 		"react-hook-form": "^7.58.1",
@@ -51,10 +55,10 @@
 		"@types/node": "^24",
 		"@types/react": "^19.2.7",
 		"@types/react-dom": "^19.2.3",
-		"drizzle-kit": "^0.31.1",
+		"drizzle-kit": "^0.31.10",
 		"tw-animate-css": "^1.3.4",
 		"typescript": "^5.9.3",
-		"vercel": "^54.13.0",
+		"vercel": "^54.21.1",
 		"vitest": "^4.1.0"
 	}
 }


### PR DESCRIPTION
## Summary
- refresh Next.js, PostCSS, drizzle-kit, and Vercel CLI within their existing release lines
- override vulnerable transitive `tar`, `brace-expansion`, and `js-yaml` versions with compatible patched releases
- repair and regenerate the npm lockfile under Node 24

## Validation
- `npm ci` (Node 24.18.0 / npm 11.16.0)
- `npm run typecheck`
- `DATABASE_URL=postgresql://wikiweaver:wikiweaver@localhost:5432/wikiweaver npm run test -- --run` (20/20)
- `npm exec -- biome check .` (passes with 3 pre-existing `!important` warnings)
- `npm run build` compiled successfully; local prerender then required the project database, so the Vercel preview is the environment-level build gate

This removes the critical `tar` advisory and clears the Dependabot blockers for `tar`, `brace-expansion`, and `js-yaml`. Broader AI/Next major-line changes are intentionally out of scope.