### PR TITLE
Fix regeneration of legacy empty articles

### DIFF
--- a/src/app/universe/[universeSlug]/wiki/[articleSlug]/page.tsx
+++ b/src/app/universe/[universeSlug]/wiki/[articleSlug]/page.tsx
@@ -4,6 +4,7 @@ import { db } from '@/db';
 import { articles } from '@/db/schema/article';
 import { universes } from '@/db/schema/universe';
 import { persistCompletedArticle } from '@/lib/persistArticle';
+import { removeEmptyArticlePlaceholder } from '@/lib/removeEmptyArticlePlaceholder';
 import { unslugify } from '@/lib/slugify';
 import { weaveWikiArticle } from '@/lib/weave';
 import ArticleRenderer from './components/ArticleRenderer';
@@ -23,8 +24,20 @@ async function findOrCreateArticle({
 			and(eq(universes.slug, universeSlug), eq(articles.slug, articleSlug)),
 		);
 
-	if (existingArticle) {
+	if (existingArticle?.articles.text.trim()) {
 		return existingArticle.articles.text;
+	}
+
+	if (existingArticle) {
+		const removed = await removeEmptyArticlePlaceholder(
+			existingArticle.articles,
+		);
+
+		if (removed) {
+			console.warn(
+				`Removed empty article placeholder: ${universeSlug} / ${articleSlug}`,
+			);
+		}
 	}
 
 	const title = unslugify(articleSlug);

--- a/src/lib/removeEmptyArticlePlaceholder.spec.ts
+++ b/src/lib/removeEmptyArticlePlaceholder.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { returning, where, deleteArticle } = vi.hoisted(() => {
+	const returning = vi.fn();
+	const where = vi.fn(() => ({ returning }));
+	const deleteArticle = vi.fn(() => ({ where }));
+
+	return { returning, where, deleteArticle };
+});
+
+vi.mock('@/db', () => ({
+	db: { delete: deleteArticle },
+}));
+
+import { removeEmptyArticlePlaceholder } from './removeEmptyArticlePlaceholder';
+
+describe('removeEmptyArticlePlaceholder', () => {
+	beforeEach(() => {
+		returning.mockReset();
+		where.mockClear();
+		deleteArticle.mockClear();
+	});
+
+	test('leaves completed articles untouched', async () => {
+		await expect(
+			removeEmptyArticlePlaceholder({
+				id: 'article-id',
+				text: '# A completed article',
+			}),
+		).resolves.toBe(false);
+
+		expect(deleteArticle).not.toHaveBeenCalled();
+	});
+
+	test('deletes an unchanged empty placeholder', async () => {
+		returning.mockResolvedValue([{ id: 'article-id' }]);
+
+		await expect(
+			removeEmptyArticlePlaceholder({ id: 'article-id', text: '   ' }),
+		).resolves.toBe(true);
+
+		expect(deleteArticle).toHaveBeenCalledTimes(1);
+		expect(where).toHaveBeenCalledTimes(1);
+	});
+
+	test('does not claim a placeholder changed by another request', async () => {
+		returning.mockResolvedValue([]);
+
+		await expect(
+			removeEmptyArticlePlaceholder({ id: 'article-id', text: '' }),
+		).resolves.toBe(false);
+	});
+});

--- a/src/lib/removeEmptyArticlePlaceholder.ts
+++ b/src/lib/removeEmptyArticlePlaceholder.ts
@@ -1,0 +1,24 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '@/db';
+import { articles } from '@/db/schema/article';
+
+interface ArticleCandidate {
+	id: string;
+	text: string;
+}
+
+export async function removeEmptyArticlePlaceholder({
+	id,
+	text,
+}: ArticleCandidate): Promise<boolean> {
+	if (text.trim()) {
+		return false;
+	}
+
+	const [deletedArticle] = await db
+		.delete(articles)
+		.where(and(eq(articles.id, id), eq(articles.text, text)))
+		.returning({ id: articles.id });
+
+	return Boolean(deletedArticle);
+}


### PR DESCRIPTION
## What changed

- treat whitespace-only article rows as incomplete instead of returning an empty stream
- delete an empty placeholder only when its ID and original text are unchanged
- regenerate and persist the article through the normal completion path
- add tests covering completed articles, empty placeholders, and concurrent changes

## Why

Legacy zero-content rows cause the article page to stay on **Weaving article…** forever because their presence bypasses generation. This was reproduced on `chronicles-of-the-primal-fool/whispering-woods`; after removing that exact empty placeholder, production generated and persisted a complete 6,671-character article.

## Verification

- `npm test -- --run` — 23 tests passed
- `npm run typecheck` — passed
- Biome check on the three changed files — passed
- production recovery verified end-to-end on the affected page